### PR TITLE
Fix build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ authors = [
     "Axel Bonnet <axel.bonnet@creatis.insa-lyon.fr>"
 ]
 readme = "README.md"
+packages = [
+    { include = "moteur-server-rest" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
`poetry build`, which is needed to produce a deliverable Python package, is currently broken on `main`, and current PR #6 doesn't appear to fix it so far. The present PR does, by specifying the source directory in `pyproject.toml`.

An alternative fix, more conflict-prone, would be to leave `pyproject.toml` unchanged and to use default filenames as expected by poetry : an `src` directory and a `moteur_server_rest.py` normalized filename as the entry point :
```
mv moteur-server-rest src
mv src/server.py src/moteur_server_rest.py
```
