### PR TITLE
add ram limitation

### DIFF
--- a/moteur_server_rest/config.py
+++ b/moteur_server_rest/config.py
@@ -10,3 +10,6 @@ def get_env_variable(var_name, default=None, required=True):
 def get_workflow_filename():
     """Helper function to get workflow file name"""
     return os.getenv("WORKFLOW_FILE_NAME", "workflow.json")
+
+def get_ram_per_workflow():
+    return int(get_env_variable("RAM_WORKFLOW", 256, required=False))

--- a/moteur_server_rest/routes.py
+++ b/moteur_server_rest/routes.py
@@ -2,15 +2,13 @@ import logging
 import base64
 import random
 import os
-import subprocess
 from flask import Flask, request, jsonify
 from moteur_server_rest.file_utils import create_directory, write_file
+from moteur_server_rest.sys_utils import get_allowed_ram, is_enough_ram
 from moteur_server_rest.workflow_manager import find_process_pids, launch_workflow, kill_workflow, process_settings
 from moteur_server_rest.config import get_env_variable
 from moteur_server_rest.config import get_workflow_filename
 from moteur_server_rest.auth import auth
-import logging
-
 
 logger = logging.getLogger(__name__)
 app = Flask(__name__)
@@ -18,8 +16,11 @@ app = Flask(__name__)
 @app.route('/submit', methods=['POST'])
 @auth.login_required
 def handle_submit():
+    if not is_enough_ram():
+        logger.warning(f"Not enough ram to launch another workflow. (max: {get_allowed_ram()}M)")
+        return jsonify({"error": "Not enough ram to launch workflow!"}), 503
     document_root = get_env_variable("WORKFLOWS_ROOT", required=True)
-    
+
     alpanum = 'abcdefghijklmnopqrstuvwxyz0123456789'
     workflow_id = f"workflow-{''.join(random.choices(alpanum, k=6))}"
     while os.path.exists(os.path.join(document_root, workflow_id)):

--- a/moteur_server_rest/routes.py
+++ b/moteur_server_rest/routes.py
@@ -4,7 +4,7 @@ import random
 import os
 from flask import Flask, request, jsonify
 from moteur_server_rest.file_utils import create_directory, write_file
-from moteur_server_rest.sys_utils import get_allowed_ram, is_enough_ram
+from moteur_server_rest.sys_utils import is_enough_ram
 from moteur_server_rest.workflow_manager import find_process_pids, launch_workflow, kill_workflow, process_settings
 from moteur_server_rest.config import get_env_variable
 from moteur_server_rest.config import get_workflow_filename
@@ -17,7 +17,7 @@ app = Flask(__name__)
 @auth.login_required
 def handle_submit():
     if not is_enough_ram():
-        logger.warning(f"Not enough ram to launch another workflow. (max: {get_allowed_ram()}M)")
+        logger.warning("Not enough ram to launch workflow!")
         return jsonify({"error": "Not enough ram to launch workflow!"}), 503
     document_root = get_env_variable("WORKFLOWS_ROOT", required=True)
 

--- a/moteur_server_rest/sys_utils.py
+++ b/moteur_server_rest/sys_utils.py
@@ -1,6 +1,6 @@
 import logging
 import subprocess
-from moteur_server_rest.config import get_env_variable
+from moteur_server_rest.config import get_env_variable, get_ram_per_workflow
 from moteur_server_rest.workflow_manager import get_number_running_workflows
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ def get_allowed_ram() -> int:
     return total_ram * (allowed_percentage / 100)
 
 def is_enough_ram() -> bool:
-    ram_per_worflow = int(get_env_variable("RAM_WORKFLOW", 256, required=True))
+    ram_per_worflow = get_ram_per_workflow()
 
     running = get_number_running_workflows()
     used = running * ram_per_worflow

--- a/moteur_server_rest/sys_utils.py
+++ b/moteur_server_rest/sys_utils.py
@@ -1,6 +1,9 @@
+import logging
 import subprocess
 from moteur_server_rest.config import get_env_variable
 from moteur_server_rest.workflow_manager import get_number_running_workflows
+
+logger = logging.getLogger(__name__)
 
 def get_max_ram() -> int:
     grep = subprocess.run(
@@ -22,7 +25,11 @@ def get_allowed_ram() -> int:
 def is_enough_ram() -> bool:
     ram_per_worflow = int(get_env_variable("RAM_WORKFLOW", 256, required=True))
 
-    used = get_number_running_workflows() * ram_per_worflow
+    running = get_number_running_workflows()
+    used = running * ram_per_worflow
     allowed = get_allowed_ram()
+    result = used + ram_per_worflow < allowed
 
-    return used + ram_per_worflow < allowed
+    if not result:
+        logger.warning(f"RAM limit reached: {used}/{allowed}mb ({running} workflows)")
+    return result

--- a/moteur_server_rest/sys_utils.py
+++ b/moteur_server_rest/sys_utils.py
@@ -1,0 +1,28 @@
+import subprocess
+from moteur_server_rest.config import get_env_variable
+from moteur_server_rest.workflow_manager import get_number_running_workflows
+
+def get_max_ram() -> int:
+    grep = subprocess.run(
+        ["grep", "MemTotal", "/proc/meminfo"],
+        capture_output=True,
+        check=True,
+    )
+    output = grep.stdout.decode().strip()
+    value = int(output.split()[1])
+    # convert result into mB
+    return int(value / 1000)
+
+def get_allowed_ram() -> int:
+    total_ram = get_max_ram()
+    allowed_percentage = int(get_env_variable("RAM_ALLOWED_PERCENTAGE", "80", required=False))
+
+    return total_ram * (allowed_percentage / 100)
+
+def is_enough_ram() -> bool:
+    ram_per_worflow = int(get_env_variable("RAM_WORKFLOW", 256, required=True))
+
+    used = get_number_running_workflows() * ram_per_worflow
+    allowed = get_allowed_ram()
+
+    return used + ram_per_worflow < allowed

--- a/moteur_server_rest/workflow_manager.py
+++ b/moteur_server_rest/workflow_manager.py
@@ -18,6 +18,18 @@ def set_docker_available(status: bool):
     DOCKER_AVAILABLE = status
     logger.info(f"Docker available: {DOCKER_AVAILABLE}")
 
+def get_number_running_workflows() -> int:
+    user = get_env_variable('USER', required=True)
+    moteur_process_class = get_env_variable('MOTEUR_MAIN_CLASS', required=True)
+    result = subprocess.run(
+        ["pgrep", "-u", user, "-f", f"{moteur_process_class}.*"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False
+    )
+    output = result.stdout.decode().strip()
+    return len(output.splitlines()) if output else 0
+
 def find_process_pids(workflow_id):
     user = get_env_variable('USER', required=True)
     moteur_process_class = get_env_variable('MOTEUR_MAIN_CLASS', required=True)
@@ -45,6 +57,7 @@ def launch_workflow(base_path: str, proxy_file: str = None) -> int:
     moteur_home     = get_env_variable('MOTEUR_HOME',     required=True)
     conf_location   = get_env_variable('CONF_LOCATION',   required=True)
     moteur_main_cls = get_env_variable('MOTEUR_MAIN_CLASS', required=True)
+    ram = get_env_variable('RAM_WORKFLOW', 256, required=False)
 
     wf_file   = os.path.join(base_path, get_workflow_filename())
     input_file  = os.path.join(base_path, 'inputs.json')
@@ -53,13 +66,14 @@ def launch_workflow(base_path: str, proxy_file: str = None) -> int:
     # Construction de la commande
     cmd = shlex.split(java_cmd_tpl.format(
         JAVA_HOME=java_home,
+        RAM_WORKFLOW=ram,
         CONF_LOCATION=conf_location,
         PROXY_FILE=proxy_arg,
         MOTEUR_HOME=moteur_home,
         MOTEUR_MAIN_CLASS=moteur_main_cls,
         workflow_id=workflow_id,
         workflow_file_path=wf_file,
-        inputs_file_path=input_file,
+        inputs_file_path=input_file
     ))
 
     out_path = os.path.join(base_path, 'process.out')
@@ -134,8 +148,6 @@ def kill_workflow(workflow_id):
         return True
     except RuntimeError:
         return False
-
-
 
 def process_settings(config, conf_dir, executor_config):
     """Process and write configuration settings."""

--- a/moteur_server_rest/workflow_manager.py
+++ b/moteur_server_rest/workflow_manager.py
@@ -6,7 +6,7 @@ import subprocess
 import shlex
 import threading
 from moteur_server_rest.jvm_utils import load_classpath
-from moteur_server_rest.config import get_env_variable
+from moteur_server_rest.config import get_env_variable, get_ram_per_workflow
 from moteur_server_rest.config import get_workflow_filename
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def launch_workflow(base_path: str, proxy_file: str = None) -> int:
     moteur_home     = get_env_variable('MOTEUR_HOME',     required=True)
     conf_location   = get_env_variable('CONF_LOCATION',   required=True)
     moteur_main_cls = get_env_variable('MOTEUR_MAIN_CLASS', required=True)
-    ram = get_env_variable('RAM_WORKFLOW', 256, required=False)
+    ram = get_ram_per_workflow()
 
     wf_file   = os.path.join(base_path, get_workflow_filename())
     input_file  = os.path.join(base_path, 'inputs.json')

--- a/msr.conf.vip
+++ b/msr.conf.vip
@@ -23,7 +23,13 @@ WORKFLOW_FILE_NAME=workflow.json
 USER=vip
 
 # Java command that is used to launch workflows
-JAVA_COMMAND={JAVA_HOME}/bin/java -Xmx950M -XX:-UseGCOverheadLimit -Duser.home={CONF_LOCATION} {PROXY_FILE} {MOTEUR_MAIN_CLASS} {workflow_id} {workflow_file_path} {inputs_file_path}
+JAVA_COMMAND={JAVA_HOME}/bin/java -Xmx{RAM_WORKFLOW}M -XX:-UseGCOverheadLimit -Duser.home={CONF_LOCATION} {PROXY_FILE} {MOTEUR_MAIN_CLASS} {workflow_id} {workflow_file_path} {inputs_file_path}
+
+# By default 80% is dedicated to workflows
+RAM_ALLOWED_PERCENTAGE=80
+
+# Ram per workflow by default 256Mb
+RAM_WORKFLOW=256
 
 # Main Java class name used to find process
 MOTEUR_MAIN_CLASS=fr.insalyon.creatis.moteurlite.MoteurLite


### PR DESCRIPTION
This pull request add a new functionality on moteur-server-rest: **limitation of RAM usage**.

Indeed, RAM per workflow was already limited, but the number of JVMs was unlimited, which could lead to crash.

To avoid that, we added new properties in the configuration file:
- **RAM_ALLOWED_PERCENTAGE**: the percentage of RAM dedicated to the workflows (by default 80%)
- **RAM_WORKFLOW**: the RAM dedicated for a specific JVM in Mb (by default 256)

> [!NOTE]
> On docker the `get_max_ram()` function will return the host value instead of the actual good one defined by docker (`docker run -m 512M`, for example)